### PR TITLE
chained guzzle exception to TokenResponseException

### DIFF
--- a/src/OAuth/Common/Http/Client/GuzzleClient.php
+++ b/src/OAuth/Common/Http/Client/GuzzleClient.php
@@ -95,9 +95,9 @@ class GuzzleClient extends AbstractClient
                 throw new TokenResponseException('Server returned HTTP response code '.$response->getStatusCode());
             }
         } catch (BadResponseException $e) {
-            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage());
+            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage(), null, $e);
         } catch (CurlException $e) {
-            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage());
+            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage(), null, $e);
         }
 
         return $response->getBody(true);


### PR DESCRIPTION
made the guzzle and curl exceptions on retrieveResponse chain on retrieveResponse. This is useful for debugging if you need to see the response of the API request

**This feature would only work in php >5.3**

example:

```
try {
    $response = $service->request($uri);
} catch (OAuth\Common\Http\Exception\TokenResponseException $e) {
    if ('Guzzle\Http\Exception\ClientErrorResponseException' === get_class($e->getPrevious()) {
        die($e->getPrevious()->getResponse()->getMessage());
    }
}
```
